### PR TITLE
Fixing repo reference

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/rneugeba/iso9660wrap"
+	"github.com/rn/iso9660wrap"
 )
 
 func printUsage() {


### PR DESCRIPTION
Built & tested on Windows with:

```
go build -o iso9660wrap.exe cmd/main.go
```

Succeeds now. Used to fail with old username:

```
go build -o iso9660wrap cmd/main.go
md\main.go:8:2: cannot find package "github.com/rneugeba/iso9660wrap" in any of:
       C:\Go\src\github.com\rneugeba\iso9660wrap (from $GOROOT)
       C:\Users\Patrick\Source\go\src\github.com\rneugeba\iso9660wrap (from $GOPATH)
```